### PR TITLE
Add forced caching functionality

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-cache (0.2.5)
+    graphql-cache (0.3.0)
       graphql (~> 1.8.0)
 
 GEM
@@ -16,7 +16,7 @@ GEM
     coderay (1.1.2)
     diff-lcs (1.3)
     docile (1.3.0)
-    graphql (1.8.4)
+    graphql (1.8.5)
     json (2.1.0)
     method_source (0.9.0)
     mini_cache (1.1.0)
@@ -63,4 +63,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/README.md
+++ b/README.md
@@ -79,17 +79,33 @@ Any object, list, or connection field can be cached by simply adding `cache: tru
 field :calculated_field, Int, cache: true
 ```
 
+### Custom Expirations
+
 By default all keys will have an expiration of `GraphQL::Cache.expiry` which defaults to 90 minutes.  If you want to set a field-specific expiration time pass a hash to the `cache` parameter like this:
 
 ```ruby
 field :calculated_field, Int, cache: { expiry: 10800 } # expires key after 180 minutes
 ```
 
-When passing a hash in the `cache` parameter the possible options are:
+### Custom cache keys
 
-- `expiry`: expiration time for this field's key in seconds (default: 5400)
-- `force`: for cache misses on this field (default: false)
-- `prefix`: cache key prefix (appended after GraphQL::Cache.namespace)
+GraphQL Cache generates a cache key using the context of a query during execution. A custom key can be included to implement versioned caching as well. By providing a `:key` value to the cache config hash on a field definition.  For example, to use a custom method that returns the cache key for an object use:
+
+```ruby
+field :calculated_field, Int, cache: { key: :custom_cache_key }
+```
+
+With this configuration the cache key used for this resolved value will use the result of the method `custom_cache_key` called on the parent object.
+
+### Forcing the cache
+
+It is possible to force graphql-cache to resolve and write all cached fields to cache regardless of the presence of a given key in the cache store.  This will effectively "renew" any existing cached expirations and warm any that don't exist. To use forced caching, add a value to `:force_cache` in the query context:
+
+```ruby
+MySchema.execute('{ company(id: 123) { cachedField }}', context: { force_cache: true })
+```
+
+This will resolve all cached fields using the field's resolver and write them to cache without first reading the value at their respective cache keys.  This is useful for structured cache warming strategies where the cache expiration needs to be updated when a warming query is made.
 
 ## Development
 

--- a/lib/graphql/cache.rb
+++ b/lib/graphql/cache.rb
@@ -17,10 +17,6 @@ module GraphQL
       # @return [Integer] Default: 5400 (90 minutes)
       attr_accessor :expiry
 
-      # When truthy, override all caching (force evalutaion of resolvers)
-      # @return [Boolean] Default: false
-      attr_accessor :force
-
       # Logger instance to use when logging cache hits/misses.
       # @return [Logger]
       attr_accessor :logger
@@ -43,7 +39,6 @@ module GraphQL
 
     # Default configuration
     @expiry    = 5400
-    @force     = false
     @namespace = 'graphql'
 
     # Called by plugin framework in graphql-ruby to

--- a/lib/graphql/cache/fetcher.rb
+++ b/lib/graphql/cache/fetcher.rb
@@ -2,27 +2,30 @@ module GraphQL
   module Cache
     class Fetcher
       def instrument(type, field)
-        old_resolve_proc = field.resolve_proc
+        return field unless field.metadata[:cache]
 
-        new_resolve_proc = lambda do |obj, args, ctx|
-          unless field.metadata[:cache]
-            return old_resolve_proc.call(obj, args, ctx)
-          end
-
-          key = cache_key(obj, args, type, field)
-
-          Marshal[key].read(field.metadata[:cache]) do
-            old_resolve_proc.call(obj, args, ctx)
-          end
-        end
+        cached_resolve_proc = cached_resolve(type, field)
 
         # Return a copy of `field`, with the new resolve proc
-        field.redefine { resolve(new_resolve_proc) }
+        field.redefine { resolve(cached_resolve_proc) }
       end
 
       # @private
       def cache_key(obj, args, type, field)
         Key.new(obj, args, type, field).to_s
+      end
+
+      # @private
+      def cached_resolve(type, field)
+        old_resolve_proc = field.resolve_proc
+
+        lambda do |obj, args, ctx|
+          key = cache_key(obj, args, type, field)
+
+          Marshal[key].read(field.metadata[:cache], force: ctx[:force_cache]) do
+            old_resolve_proc.call(obj, args, ctx)
+          end
+        end
       end
     end
   end

--- a/lib/graphql/cache/marshal.rb
+++ b/lib/graphql/cache/marshal.rb
@@ -29,7 +29,10 @@ module GraphQL
       #
       # @param config [Hash] The object passed to `cache:` on the field definition
       # @return [Object]
-      def read(config, &block)
+      def read(config, force: false, &block)
+        # write new data from resolver if forced
+        return write(config, &block) if force
+
         cached = cache.read(key)
 
         if cached.nil?

--- a/spec/graphql/cache/fetcher_spec.rb
+++ b/spec/graphql/cache/fetcher_spec.rb
@@ -13,7 +13,8 @@ module GraphQL
           double(
             'graphql-ruby field',
             resolve_proc: ->(obj, args, ctx) { nil },
-            redefine: nil
+            redefine: nil,
+            metadata: { cache: true }
           )
         end
 

--- a/spec/graphql/cache/marshal_spec.rb
+++ b/spec/graphql/cache/marshal_spec.rb
@@ -34,6 +34,18 @@ module GraphQL
         let(:config) { true }
         let(:block) { double('block', call: 'foo') }
 
+        context 'when force is set' do
+          it 'should execute the block' do
+            expect(block).to receive(:call)
+            subject.read(config, force: true) { block.call }
+          end
+
+          it 'should write to cache' do
+            expect(cache).to receive(:write).with(key, doc, expires_in: GraphQL::Cache.expiry)
+            subject.write(config) { doc }
+          end
+        end
+
         context 'when cache object exists' do
           before do
             cache.write(key, doc)

--- a/spec/graphql/cache_spec.rb
+++ b/spec/graphql/cache_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe GraphQL::Cache do
     it { should respond_to :expiry }
     it { should respond_to :expiry= }
 
-    it { should respond_to :force }
-    it { should respond_to :force= }
 
     it { should respond_to :namespace }
     it { should respond_to :namespace= }
@@ -29,10 +27,10 @@ RSpec.describe GraphQL::Cache do
     describe '#configure' do
       it 'should yield self to allow setting config' do
         expect{
-          described_class.configure { |c| c.force = true }
+          described_class.configure { |c| c.expiry = 1234 }
         }.to change{
-          described_class.force
-        }.to true
+          described_class.expiry
+        }.to 1234
       end
     end
   end


### PR DESCRIPTION
Problem
-------
Currently there is no way to forcibly "renew" cached values.

Solution
--------
I've added a check for `force_cache` in the query context which will resolve a field _AND_ write it to cache regardless of the existence of a value at the cache key.  This effectively renews the expiration on the cache key allowing for warming the cache.

To use this new functionality a truthy value must be passed in the query context:

```ruby
MySchema.execute(query, context: { force_cache: true })
```

Resolves #32 