### PR TITLE
Allow cache keys to expire on Rails 5.2

### DIFF
--- a/lib/graphql/cache/key.rb
+++ b/lib/graphql/cache/key.rb
@@ -90,6 +90,7 @@ module GraphQL
 
       # @private
       def guess_id
+        return object.cache_key_with_version if object.respond_to?(:cache_key_with_version)
         return object.cache_key if object.respond_to?(:cache_key)
         return object.id if object.respond_to?(:id)
         object.object_id

--- a/lib/graphql/cache/version.rb
+++ b/lib/graphql/cache/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Cache
-    VERSION = '0.4.0'
+    VERSION = '0.5.0'
   end
 end


### PR DESCRIPTION
Cause (for defects/bugs)
------------------------

Our current implementation means that model keys never expire on new Rails 5.2 apps. Cf issue #35 .

Solution
--------

Use Rails 5.2's `cache_key_with_version` if possible.

This is a quick fix to address the most pressing issue of cache keys never expiring.
However, using a key with version doesn't leverage Rails 5.2 key recycling. We should support Rails 5.2 key recycling in the future, but this can be a separate PR.