### PR TITLE
Integration testing against Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.6
   - 2.5
   - 2.4
   - 2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ gemfile:
   - gemfiles/graphql_1.8.gemfile
   - gemfiles/graphql_1.9.gemfile
 before_script:
-  - gem install bundler
+  - gem update --system
+  - gem install bundler -v 1.17.3
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
+  - 2.5
+  - 2.4
+  - 2.3
 gemfile:
   - gemfiles/graphql_1.8.gemfile
   - gemfiles/graphql_1.9.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ gemfile:
   - gemfiles/graphql_1.8.gemfile
   - gemfiles/graphql_1.9.gemfile
 before_script:
-  - gem update --system
-  - gem install bundler -v 1.17.3
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-cache (0.6.0)
+    graphql-cache (0.5.0)
       graphql (~> 1, > 1.8)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,6 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
-  bundler (~> 2.0)
   codeclimate-test-reporter
   graphql-cache!
   mini_cache
@@ -63,4 +62,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.0.1
+   1.17.3

--- a/graphql-cache.gemspec
+++ b/graphql-cache.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2.0' # bc graphql-ruby requires >= 2.2.0
 
   s.add_development_dependency 'appraisal'
-  s.add_development_dependency 'bundler', '~> 2.0'
   s.add_development_dependency 'codeclimate-test-reporter'
   s.add_development_dependency 'mini_cache'
   s.add_development_dependency 'pry'


### PR DESCRIPTION
Problem
-------
We're on the heels of Ruby 2.3 dropping out of support and ruby 2.6 is seeing serious production usage.  It's time we start testing against 2.6.

Solution
--------
There a few things here:

1. Removed explicit bundler install in `before_install` in travis config...turns out, travis is doing more autodetection than I knew and bundler and the gem bundle were being installed/created before these scripts even ran.
2. Remove individual patch versions of ruby so that we'll build against the current patch version each time
3. Added Ruby 2.6 to our test matrix config
4. I also reverted the Gemfile.lock bundler version change because of weirdness getting bundler 2 and ruby 2.6 to work together on Travis.

Notes
-----
I also removed a premature version bump in GraphQL::Cache::VERSION

Resolves #41 