### PR TITLE
Bump minor version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-cache (0.5.0)
+    graphql-cache (0.6.0)
       graphql (~> 1, > 1.8)
 
 GEM

--- a/lib/graphql/cache/version.rb
+++ b/lib/graphql/cache/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Cache
-    VERSION = '0.5.0'
+    VERSION = '0.6.0'.freeze
   end
 end


### PR DESCRIPTION
[0.5.0 -> 0.6.0](https://github.com/stackshareio/graphql-cache/releases/tag/untagged-b9591d57c2f3e6a21306)