### PR TITLE
Use proper GitHub org name in homepage

### DIFF
--- a/graphql-cache.gemspec
+++ b/graphql-cache.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.summary       = 'Caching middleware for graphql-ruby'
   s.description   = 'Provides middleware field-level caching for graphql-ruby'
-  s.homepage      = 'https://github.com/Leanstack/graphql-cache'
+  s.homepage      = 'https://github.com/stackshareio/graphql-cache'
   s.license       = 'MIT'
 
   s.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
Problem
-------

Stackshare changed their Github org name from "Leanstack" to
"stackshareio" and though Github is still redirecting that URL properly
we should use the proper URL since it is the one registered on
RubyGems.org

Solution
--------
Update gemspec homepage url