### PR TITLE
Add note about interface field classes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ $ gem install graphql-cache
     end
   end
   ```
+_Also note that if you want access to the `cache` keyword param in interface fields, the field_class directive must be added to your base interface module as well_
 
 ## Configuration
 


### PR DESCRIPTION
Problem
-------
Our instructions are a little unclear on how to deal with errors like `unknown keyword: cache` when trying to add caching to a field defined on an interface

Cause (for defects/bugs)
------------------------
Object types and interfaces both allow the use of a custom field class (used by graphql-cache to accept the `cache` keyword param on field definitions.  Our README instructs users to add the custom field to their base object type, but it's unclear how to use the gem with interface types.

Solution
--------
I added a quick note to the custom field class section of the README regarding use of `cache` in interfaces.

resolves #46 