### PR TITLE
Pass context through to key generation proc

### DIFF
--- a/lib/graphql/cache/fetcher.rb
+++ b/lib/graphql/cache/fetcher.rb
@@ -30,7 +30,7 @@ module GraphQL
         old_resolve_proc = field.resolve_proc
 
         lambda do |obj, args, ctx|
-          key = cache_key(obj, args, type, field)
+          key = cache_key(obj, args, type, field, ctx)
 
           value = Marshal[key].read(
             field.metadata[:cache], force: ctx[:force_cache]

--- a/lib/graphql/cache/fetcher.rb
+++ b/lib/graphql/cache/fetcher.rb
@@ -21,8 +21,8 @@ module GraphQL
       end
 
       # @private
-      def cache_key(obj, args, type, field)
-        Key.new(obj, args, type, field).to_s
+      def cache_key(obj, args, type, field, ctx)
+        Key.new(obj, args, type, field, ctx).to_s
       end
 
       # @private

--- a/lib/graphql/cache/resolver.rb
+++ b/lib/graphql/cache/resolver.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Cache
+    # Represents the caching resolver that wraps the existing resolver proc
+    class Resolver
+      attr_accessor :type
+
+      attr_accessor :field
+
+      attr_accessor :orig_resolve_proc
+
+      def initialize(type, field)
+        @type  = type
+        @field = field
+      end
+
+      def call(obj, args, ctx)
+        @orig_resolve_proc = field.resolve_proc
+
+        key = cache_key(obj, args, ctx)
+
+        value = Marshal[key].read(
+          field.metadata[:cache], force: ctx[:force_cache]
+        ) do
+          @orig_resolve_proc.call(obj, args, ctx)
+        end
+
+        wrap_connections(value, args, parent: obj, context: ctx)
+      end
+
+      protected
+
+      # @private
+      def cache_key(obj, args, ctx)
+        Key.new(obj, args, type, field, ctx).to_s
+      end
+
+      # @private
+      def wrap_connections(value, args, **kwargs)
+        # return raw value if field isn't a connection (no need to wrap)
+        return value unless field.connection?
+
+        # return cached value if it is already a connection object
+        # this occurs when the value is being resolved by GraphQL
+        # and not being read from cache
+        return value if value.class.ancestors.include?(
+          GraphQL::Relay::BaseConnection
+        )
+
+        create_connection(value, args, **kwargs)
+      end
+
+      # @private
+      def create_connection(value, args, **kwargs)
+        GraphQL::Relay::BaseConnection.connection_for_nodes(value).new(
+          value,
+          args,
+          field: field,
+          parent: kwargs[:parent],
+          context: kwargs[:context]
+        )
+      end
+    end
+  end
+end

--- a/spec/graphql/cache/key_spec.rb
+++ b/spec/graphql/cache/key_spec.rb
@@ -72,15 +72,15 @@ module GraphQL
 
         context 'when metadata key is a proc' do
           let(:key_proc) do
-            -> (obj) { 'baz' }
+            -> (obj, ctx) { 'baz' }
           end
 
           before do
             field.metadata[:cache] = { key: key_proc }
           end
 
-          it 'calls the proc passing object' do
-            expect(key_proc).to receive(:call).and_call_original
+          it 'calls the proc passing object and query context' do
+            expect(key_proc).to receive(:call).with(obj, {}).and_call_original
             subject.object_identifier
           end
         end


### PR DESCRIPTION
Problem
-------
Values from the current GQL query context were not available in any cache key context, meaning that a key could not be based off of the current user for example.

Solution
--------
We have access to the query context during our cache resolver method, it just never got passed through to the underlying implementation of `Graphql::Cache::Key`.  I've added a param to the key initializer for the query context and passed it as a param to the provided Proc.

Notes
-----
This is technically a breaking change right now.  The added proc param will cause existing implementations to fail if they don't accept the second parameter.  I'm going to circle back soon to see if there's a good way to do this without disrupting the existing API.

To Do
--------
- [ ] Use a ruby object that responds to `call` instead of replacement lamda in `Fetcher`
- [ ] Refactor param passing in `Fetcher` and `Key` to reduce param lists and verbosity in methods

[resolve #49]