### PR TITLE
Add first pass for wrapping connection cache data

### DIFF
--- a/lib/graphql/cache/fetcher.rb
+++ b/lib/graphql/cache/fetcher.rb
@@ -38,14 +38,14 @@ module GraphQL
             old_resolve_proc.call(obj, args, ctx)
           end
 
-          wrap_connections(value, args, field, obj, ctx)
+          wrap_connections(value, args, field: field, parent: obj, context: ctx)
         end
       end
 
       # @private
-      def wrap_connections(value, args, field, obj, ctx)
+      def wrap_connections(value, args, **kwargs)
         # return raw value if field isn't a connection (no need to wrap)
-        return value unless field.connection?
+        return value unless kwargs[:field].connection?
 
         # return cached value if it is already a connection object
         # this occurs when the value is being resolved by GraphQL
@@ -54,17 +54,17 @@ module GraphQL
           GraphQL::Relay::BaseConnection
         )
 
-        create_connection(value, args, field, obj, ctx)
+        create_connection(value, args, **kwargs)
       end
 
       # @private
-      def create_connection(value, args, field, obj, ctx)
+      def create_connection(value, args, **kwargs)
         GraphQL::Relay::BaseConnection.connection_for_nodes(value).new(
           value,
           args,
-          field: field,
-          parent: obj,
-          context: ctx
+          field: kwargs[:field],
+          parent: kwargs[:parent],
+          context: kwargs[:context]
         )
       end
     end

--- a/spec/features/connections_spec.rb
+++ b/spec/features/connections_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+def execute(query, context = {})
+  CacheSchema.execute(query, context: context)
+end
+
+RSpec.describe 'caching connection fields' do
+  let(:query) do
+    %Q{
+      {
+        customer(id: #{Customer.last.id}) {
+          orders {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+  end
+
+  it 'produces the same result on miss or hit' do
+    cold_results = execute(query)
+    warm_results = execute(query)
+
+    expect(cold_results).to eq warm_results
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,8 @@ RSpec.configure do |config|
   config.before(:suite) do
     GraphQL::Cache.cache  = TestCache.new
     GraphQL::Cache.logger = TestLogger.new
+
+    DB.logger = GraphQL::Cache.logger
   end
 
   # required after GraphQL::Cache initialization because dev


### PR DESCRIPTION
Problem
-------
Caching connection fields in graphql-ruby 1.9 results in a `NoMethodError: undefined method 'edge_nodes' for...` error

Cause (for defects/bugs)
------------------------
graphql-ruby 1.9's GraphQL::Relay::EdgesInstrumentation expects the resolver returned value to respond to `edge_nodes` (like an actual relay connection would).

Solution
--------
Do our own wrapping of connection-able cached data using `GraphQL::Relay::BaseConnection::CONNECTION_IMPLEMENTATIONS`

Resolves #53